### PR TITLE
[PLT-5378] Implementation of filter and exclude in EntityList based upon multiple filters

### DIFF
--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -611,16 +611,43 @@ exists or it belongs to a different class\_type, it throws an exception.
 
     client_assets.add(new_asset_entity)
 
+.filter 
+~~~~~~~~
+This method filters the given EntityList to return an updated list that contains only those entities which satisfy all the conditions given in arguments.
+It works with all primitive attribtues of the ``Entity`` in the ``EntityList``, if the specific operation is defined for that data type.
+
+
+It takes multiple keyword arguments as a parameter (**\*\*kwargs**) to filter the entities.
+
+For a simple filter operation that includes entities by checking for equality, the format is: `entity_attribute=value`
+
+For operators other than equality, the format is: `entity_attribute__operator=value`
+
+You can |reference_link| for a list of possible operators.
+
+.. |reference_link| raw:: html
+
+   <a href="https://docs.python.org/3/library/operator.html" target="_blank">refer here</a>
+
+
+::
+
+   filtered_entity_list = client_assets.filter(status='Inactive')
+   filtered_entity_list = client_assets.filter(country__ne='India')
+
+
+
 .exclude
 ~~~~~~~~
 
 This method filters the given EntityList to return an updated list that
-doesn't contain the entity which has the ``name`` attribute value as
-``value``.
+doesn't contain entities which satisfy any of the conditions given in arguments.
 
+It takes the same arguments as ``.filter`` above but negates the conditions to exclude them.
 ::
 
-    updated_entity_list = client_assets.exclude("id", 1)
+    updated_entity_list = client_assets.exclude(id=5)
+    updated_entity_list = client_assets.exclude(created_at__lt=first_asset.created_at)
 
 .data
 ~~~~~

--- a/quartic_sdk/core/entities/asset.py
+++ b/quartic_sdk/core/entities/asset.py
@@ -89,7 +89,7 @@ class Asset(Base):
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
-        tags = self.get_tags().exclude("tag_data_type", Constants.TAG_DATA_TYPES[Constants.SPECTRAL])
+        tags = self.get_tags().exclude(tag_data_type=Constants.TAG_DATA_TYPES[Constants.SPECTRAL])
         logging.info("Filtering to fetch data only for non-spectral tags")
         return TagDataIterator.create_tag_data_iterator(
             tags,

--- a/quartic_sdk/core/entity_helpers/entity_list.py
+++ b/quartic_sdk/core/entity_helpers/entity_list.py
@@ -90,10 +90,8 @@ class EntityList:
         negate = kwargs.pop('_negate') if '_negate' in kwargs else False
         for filter_key in kwargs:
             filter_attribute, filter_operator = filter_key.split('__') if '__' in filter_key else (filter_key, 'eq')
-            filter_value = kwargs[filter_key]
-            operator_func = getattr(operator, filter_operator)
-            filter_func = lambda x, y: not operator_func(x, y) if negate else operator_func(x, y)
-            filtered_entities = list(filter(lambda entity: filter_func(getattr(entity, filter_attribute), filter_value), filtered_entities))      
+            filter_func = lambda x, y: not getattr(operator, filter_operator)(x, y) if negate else getattr(operator, filter_operator)(x, y)
+            filtered_entities = list(filter(lambda entity: filter_func(getattr(entity, filter_attribute), kwargs[filter_key]), filtered_entities))      
         return EntityList(self._class_type, filtered_entities)
 
     def check_object_in_list(self, instance):

--- a/quartic_sdk/core/entity_helpers/entity_list.py
+++ b/quartic_sdk/core/entity_helpers/entity_list.py
@@ -124,15 +124,15 @@ class EntityList:
             raise AssertionError(
                 f"Can not add object, since it is not of {self._class_type} type")
 
-    def exclude(self, name, value):
+    def exclude(self, **kwargs):
         """
-        We return the EntityList after removing the entity with the attribute
-        name having the value as above
+        We return the EntityList after removing the entities with the attributes having the given values
+        :param kwargs: Dict which maps `filter_key` to filter_value
         """
-        updated_entities = [
-            entity_obj for entity_obj in self._entities if getattr(
-                entity_obj, name) != value]
-        return EntityList(self._class_type, updated_entities)
+        filtered_entities = set([entity.id for entity in self.filter(**kwargs)])
+        excluded_entities = [entity for entity in self._entities
+                                if entity.id not in filtered_entities]
+        return EntityList(self._class_type, excluded_entities)
 
     def __iter__(self):
         """

--- a/quartic_sdk/utilities/test_helpers.py
+++ b/quartic_sdk/utilities/test_helpers.py
@@ -59,7 +59,22 @@ TAG_LIST_MULTI_GET = [{"id": 1,
                        "short_name": "Short Tag2",
                        "edge_connector": 1,
                        "asset": 1,
-                       "tag_data_type": 0}]
+                       "tag_data_type": 0},
+                      {"id": 3,
+                       "name": "Tag3",
+                       "short_name": "Short Tag3",
+                       "edge_connector": 1,
+                       "asset": 2,
+                       "tag_data_type": 0
+                       },
+                      {"id": 4,
+                       "name": "Tag4",
+                       "short_name": "Short Tag4",
+                       "edge_connector": 2,
+                       "asset": 3,
+                       "tag_data_type": 1
+                       }
+                      ]
 TAG_LIST_DATA_POST = {
     "data": {
         "columns": [

--- a/tests/core/test_entity_list.py
+++ b/tests/core/test_entity_list.py
@@ -83,7 +83,6 @@ def test_entity_list_filter():
     """
     Test filter method of EntityList
     """
-    print(test_tag_entities_list[0].tag_data_type)
     assert test_tag_entities_list.filter(id=1).count() == 1
     assert test_tag_entities_list.filter(id__ne=1).count() == 3
     assert test_tag_entities_list.filter(tag_data_type="double").count() == 3

--- a/tests/core/test_entity_list.py
+++ b/tests/core/test_entity_list.py
@@ -77,3 +77,32 @@ def test_entity_list_first():
     Test first method of entitylist
     """
     assert asset_entity_list.first() == test_asset_entity
+
+
+def test_entity_list_filter():
+    """
+    Test filter method of EntityList
+    """
+    print(test_tag_entities_list[0].tag_data_type)
+    assert test_tag_entities_list.filter(id=1).count() == 1
+    assert test_tag_entities_list.filter(id__ne=1).count() == 3
+    assert test_tag_entities_list.filter(tag_data_type="double").count() == 3
+    assert test_tag_entities_list.filter(tag_data_type__eq="string").count() == 1
+    assert test_tag_entities_list.filter(id__le=3).count() == 3
+    assert test_tag_entities_list.filter(id__lt=3).count() == 2
+    assert test_tag_entities_list.filter(tag_data_type="double", asset=1).count() == 2
+    assert test_tag_entities_list.filter(tag_data_type="double", asset=2).count() == 1
+
+
+def test_entity_list_exclude():
+    """
+    Test exclude method of EntityList
+    """
+    assert test_tag_entities_list.exclude(id=1).count() == 3
+    assert test_tag_entities_list.exclude(tag_data_type="double").count() == 1
+    assert test_tag_entities_list.exclude(tag_data_type="string").count() == 3
+    assert test_tag_entities_list.exclude(asset=1).count() == 2
+    assert test_tag_entities_list.exclude(asset=3).count() == 3
+    assert test_tag_entities_list.exclude(id__gt=1).count() == 1
+    assert test_tag_entities_list.exclude(id__ge=1).count() == 0
+    assert test_tag_entities_list.exclude(id=1, tag_data_type="string").count() == 2

--- a/tests/features/user_interaction_flow/__init__.py
+++ b/tests/features/user_interaction_flow/__init__.py
@@ -34,6 +34,8 @@ def step_impl(context):
         world.client_assets = world.client.assets()
 
     world.first_asset = world.client_assets.first()
+    world.assets_excluding_first = world.client_assets.exclude(id=world.first_asset.id)
+    world.assets_filtered = world.client_assets.filter(id=world.first_asset.id)
 
     with mock.patch('requests.get') as requests_get:
         requests_get.return_value = TestHelpers.APIHelperCallAPI(
@@ -88,6 +90,12 @@ def step_impl(context):
     assert isinstance(world.client_asset_tags, EntityList)
     assert isinstance(world.first_asset_tags, EntityList)
     assert isinstance(world.first_tag, Tag)
+    assert isinstance(world.assets_excluding_first, EntityList)
+    for asset in world.assets_excluding_first:
+        assert isinstance(asset, Asset)
+    assert isinstance(world.assets_filtered, EntityList)
+    for asset in world.assets_filtered:
+        assert isinstance(asset, Asset)
     assert isinstance(world.first_asset_batches, EntityList)
     assert isinstance(world.first_asset_batches.first(), Batch)
     with mock.patch('requests.post') as requests_post:


### PR DESCRIPTION
Adds to following to functionalities for `EntityList`
1. filter() we can filter our entity list based on multiple arguments
2. exclude() we can get all entities in the list without the ones which satisfy the passed arguments

This should work on all attributes which are primitive objects (such as strings, integers) or any Entities which have the dunder methods defined for them such as `__le__`, `__lt__`, `__eq__`, `__ne__`, etc.