### PR TITLE
QPD-2710: Pin  charset normalizer version

### DIFF
--- a/model_requirements.in
+++ b/model_requirements.in
@@ -48,6 +48,7 @@ aiogqlc==2.2.0
 validators==0.18.2
 coloredlogs==15.0.1
 aiohttp==3.8.1
+charset-normalizer==2.1.0
 nest-asyncio==1.5.4
 click==8.0.2
 jinja2==3.0.3

--- a/requirements.in
+++ b/requirements.in
@@ -18,6 +18,7 @@ nest-asyncio==1.5.4
 six==1.15.0
 certifi==2021.5.30
 aiohttp==3.8.1
+charset-normalizer==2.1.0
 click==8.0.2
 jinja2==3.0.3
 markupsafe==2.0.1


### PR DESCRIPTION
For edge_server build resolution (EdgeServer -> powergauge -> QuarticSDK )
` charset-normalizer==2.1.0 (from external-node-lib[complete]==2.10.0b1)`
