### PR TITLE
QPD-3313: add event loop as dask new version uses thread pool

### DIFF
--- a/quartic_sdk/graphql_client.py
+++ b/quartic_sdk/graphql_client.py
@@ -50,6 +50,8 @@ class GraphqlClient:
         self.__graphql_url = self._get_graphql_url()
         self.logger = logging.getLogger()
         coloredlogs.install(level='DEBUG', logger=self.logger)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         nest_asyncio.apply()
 
     @staticmethod


### PR DESCRIPTION
Added new event loop as new dask version uses threadpool and finds no event loop. This new event loop does not clash with jupyter notebook/cli