### PR TITLE
QPD-5982: Added wide df functionality in fetching data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ asset = user_assets.get("name","Test Asset") # Get a specific asset with the nam
 asset_tags = asset.get_tags() # Gets the list of all tags
 
 first_tag=asset_tags.first() # Returns the first in the list of tags
-tag_data=first_tag.data(start_time=1000000,stop_time=2000000) # Returns the downsampled data present in the first tag for the time range of 1000000 to 2000000
+tag_data = first_tag.data(start_time=1000000,stop_time=2000000) # Returns the downsampled data present in the first tag for the time range of 1000000 to 2000000 in wide data format.
+tag_data_long = first_tag.data(start_time=1000000, stop_time=200000, wide_df=False) # Returns the same data, in long format. 
 ```
 ```python
 # For getting raw data we need to use freeflowpaginated query using Graphql Client

--- a/README.md
+++ b/README.md
@@ -168,18 +168,19 @@ while retry_count > 0:
         asset_tags = asset.get_tags()  # Gets the list of all tags
 
         first_tag = asset_tags.first()  # Returns the first in the list of tags
-        tag_data = first_tag.data(start_time=1000000, stop_time=2000000)  # Returns the data present in the first tag for the time range of 1000000 to 2000000
+        tag_data = first_tag.data(start_time=1000000,
+                                  stop_time=2000000)  # Returns the data present in the first tag for the time range of 1000000 to 2000000
 
         # If the code reaches here without exceptions, break out of the loop
         break
     except PermissionError:
-      # If the refresh token expires, this error is thrown and recreation of client is needed to update the tokens
+        # If the refresh token expires, this error is thrown and recreation of client is needed to update the tokens
         retry_count -= 1
         if retry_count > 0:
             print(f"PermissionError: Retrying in {retry_delay} seconds...")
             time.sleep(retry_delay)
         else:
-          # If still the error persist, the password might have been changed
+            # If still the error persist, the password might have been changed
             print("PermissionError: Maximum retries reached. Exiting.")
             break
 

--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -399,7 +399,7 @@ The method parameters as included in v2.0.0 are as follows:
 ~~~~~
 
 The method returns the downsampled tag data for all the tags present in the
-asset for the set ``start_time`` and ``stop_time``. Using ``sampling_value``
+asset for the set ``start_time`` and ``stop_time``. Using ``sampling_data_points``
 parameter you can control the downsampled points.
 
 The method parameters are as follows:
@@ -408,10 +408,10 @@ The method parameters are as follows:
    ``start_time`` for fetching the data of the asset.
 -  **stop\_time (mandatory)**: (epoch) This refers to the ``stop_time``
    for fetching the data of the asset.
--  **sampling_value (optional)**: This refers to the sampling_value at which
-   the downsampled data is required. If the sampling_value provided, the method returns the
-   data in the tag for the given time range with the datapoints equal to sampling_value.
-   The default sampling_value is 1500.
+-  **sampling_data_points (optional)**: This refers to the sampling_data_points at which
+   the downsampled data is required. If the sampling_data_points provided, the method returns the
+   data in the tag for the given time range with the datapoints equal to sampling_data_points.
+   The default sampling_data_points is 1500.
 -  **return\_type (optional)**: The user can pass either ``pd``, which
    will return the pandas dataframe iterator, or ``json`` which will
    return json object on return. This value takes the ``pd`` value as
@@ -512,17 +512,17 @@ The available methods are as follows:
 ~~~~~
 
 The method returns the downsampled tagdata for the selected tag for the set
-``start_time`` and ``stop_time``,Using ``sampling_value``
+``start_time`` and ``stop_time``,Using ``sampling_data_points``
 parameter you can control the downsampled points. The method parameters are as follows:
 
 -  **start\_time (mandatory)**: (epoch) Refers to the ``start_time`` for
    fetching the data of the asset.
 -  **stop\_time (mandatory)**: (epoch) Refers to the ``stop_time`` for
    fetching the data of the asset.
--  **sampling_value (optional)**: This refers to the sampling_value at which
-   the downsampled data is required. If the sampling_value provided, the method returns the
-   data in the tag for the given time range with the datapoints equal to sampling_value.
-   The default sampling_value is 1500.
+-  **sampling_data_points (optional)**: This refers to the sampling_data_points at which
+   the downsampled data is required. If the sampling_data_points provided, the method returns the
+   data in the tag for the given time range with the datapoints equal to sampling_data_points.
+   The default sampling_data_points is 1500.
 -  **return\_type (optional)**: The user can pass either ``pd``, which
    will return the pandas dataframe iterator, or ``json`` which will
    return json object on return. This value takes the ``pd`` value as
@@ -641,7 +641,7 @@ of ``EntityList`` where each object refers to ``Tag``.
 ~~~~~
 
 The method returns the downsampled tag data for all the tags present in the
-datasource for the set ``start_time`` and ``stop_time``. Using ``sampling_value``
+datasource for the set ``start_time`` and ``stop_time``. Using ``sampling_data_points``
 parameter you can control the downsampled points.
 
 The method parameters are as follows:
@@ -650,10 +650,10 @@ The method parameters are as follows:
    ``start_time`` for fetching the data of the datasource.
 -  **stop\_time (mandatory)**: (epoch) This refers to the ``stop_time``
    for fetching the data of the data ource.
--  **sampling_value (optional)**: This refers to the sampling_value at which
-   the downsampled data is required. If the sampling_value provided, the method returns the
-   data in the tag for the given time range with the datapoints equal to sampling_value.
-   The default sampling_value is 1500.
+-  **sampling_data_points (optional)**: This refers to the sampling_data_points at which
+   the downsampled data is required. If the sampling_data_points provided, the method returns the
+   data in the tag for the given time range with the datapoints equal to sampling_data_points.
+   The default sampling_data_points is 1500.
 -  **return\_type (optional)**: The user can pass either ``pd``, which
    will return the pandas dataframe iterator, or ``json`` which will
    return json object on return. This value takes the ``pd`` value as
@@ -880,10 +880,10 @@ data for given tags, and has the following parameters:
    fetching the data of the asset.
 -  **stop\_time (mandatory)**: (epoch) Refers to the ``stop_time`` for
    fetching the data of the asset.
--  **sampling_value (optional)**: This refers to the sampling_value at which
-   the downsampled data is required. If the sampling_value provided, the method returns the
-   data in the tag for the given time range with the datapoints equal to sampling_value.
-   The default sampling_value is 1500.
+-  **sampling_data_points (optional)**: This refers to the sampling_data_points at which
+   the downsampled data is required. If the sampling_data_points provided, the method returns the
+   data in the tag for the given time range with the datapoints equal to sampling_data_points.
+   The default sampling_data_points is 1500.
 -  **return\_type (optional)**: The user can pass either ``pd``, which
    will return the pandas dataframe iterator, or ``json`` which will
    return json object on return. This value takes the ``pd`` value as
@@ -896,10 +896,10 @@ TagData
 ------------------
 
 Querying data for any set of tags in any given duration returns downsampled
-tag data.Using ``sampling_value`` parameter you can control the downsampled 
+tag data.Using ``sampling_data_points`` parameter you can control the downsampled
 points. When the ``.data`` of tags/assets is called, the
 method queries for data between ``start_time`` and ``stop_time`` 
-and downsample the data points for all the tags for given ``sampling_value``.
+and downsample the data points for all the tags for given ``sampling_data_points``.
 
 HistoricalTagDataIterator
 -------------------------

--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -408,7 +408,7 @@ The method parameters are as follows:
    ``start_time`` for fetching the data of the asset.
 -  **stop\_time (mandatory)**: (epoch) This refers to the ``stop_time``
    for fetching the data of the asset.
--  **sampling_data_points (optional)**: This refers to the sampling_data_points at which
+-  **sampling\_data\_points (optional)**: This refers to the sampling_data_points at which
    the downsampled data is required. If the sampling_data_points provided, the method returns the
    data in the tag for the given time range with the datapoints equal to sampling_data_points.
    The default sampling_data_points is 1500.
@@ -419,6 +419,9 @@ The method parameters are as follows:
 -  **transformations (optional)**: The user is supposed to pass the list
    of interpolations and aggregations here. Further details on
    transformations is provided towards the end of this documentation.
+-  **wide\_df (optional)**: When passed as ``true``, the data is returned
+   in a wide format, and when passed as ``false``, it is returned in a
+   long format. By default, the setting is ``true``.
 
 Tag
 ------
@@ -519,7 +522,7 @@ parameter you can control the downsampled points. The method parameters are as f
    fetching the data of the asset.
 -  **stop\_time (mandatory)**: (epoch) Refers to the ``stop_time`` for
    fetching the data of the asset.
--  **sampling_data_points (optional)**: This refers to the sampling_data_points at which
+-  **sampling\_data_\points (optional)**: This refers to the sampling_data_points at which
    the downsampled data is required. If the sampling_data_points provided, the method returns the
    data in the tag for the given time range with the datapoints equal to sampling_data_points.
    The default sampling_data_points is 1500.
@@ -536,6 +539,10 @@ parameter you can control the downsampled points. The method parameters are as f
 -  **transformations (optional)**: The user is supposed to pass the list
    of interpolations and aggregations here. Further details on
    transformations is provided towards the end of this documentation.
+-  **wide\_df (optional)**: When passed as ``true``, the data is returned
+   in a wide format, and when passed as ``false``, it is returned in a
+   long format. By default, the setting is ``true``.
+
 
 .wavelengths
 ~~~~~~~~~~~~
@@ -650,7 +657,7 @@ The method parameters are as follows:
    ``start_time`` for fetching the data of the datasource.
 -  **stop\_time (mandatory)**: (epoch) This refers to the ``stop_time``
    for fetching the data of the data ource.
--  **sampling_data_points (optional)**: This refers to the sampling_data_points at which
+-  **sampling\_data\_points (optional)**: This refers to the sampling_data_points at which
    the downsampled data is required. If the sampling_data_points provided, the method returns the
    data in the tag for the given time range with the datapoints equal to sampling_data_points.
    The default sampling_data_points is 1500.
@@ -661,6 +668,9 @@ The method parameters are as follows:
 -  **transformations (optional)**: The user must pass the list
    of interpolations and aggregations here. Further details on
    transformations is provided towards the end of this documentation.
+-  **wide\_df (optional)**: When passed as ``true``, the data is returned
+   in a wide format, and when passed as ``false``, it is returned in a
+   long format. By default, the setting is ``true``.
 
 .historical_data
 ~~~~~~~~~~~~~~~~
@@ -880,7 +890,7 @@ data for given tags, and has the following parameters:
    fetching the data of the asset.
 -  **stop\_time (mandatory)**: (epoch) Refers to the ``stop_time`` for
    fetching the data of the asset.
--  **sampling_data_points (optional)**: This refers to the sampling_data_points at which
+-  **sampling\_data\_points (optional)**: This refers to the sampling_data_points at which
    the downsampled data is required. If the sampling_data_points provided, the method returns the
    data in the tag for the given time range with the datapoints equal to sampling_data_points.
    The default sampling_data_points is 1500.
@@ -891,6 +901,9 @@ data for given tags, and has the following parameters:
 -  **transformations (optional)**: The user must pass the list
    of interpolations and aggregations here. Further details on
    transformations is provided towards the end of this documentation.
+-  **wide\_df (optional)**: When passed as ``true``, the data is returned
+    in a wide format, and when passed as ``false``, it is returned in a
+    long format. By default, the setting is ``true``.
 
 TagData
 ------------------

--- a/docs/source/home.rst
+++ b/docs/source/home.rst
@@ -112,8 +112,12 @@ Getting the assets, tags, batches from the server
 
     asset = user_assets.get("name","Test Asset") # Get a specific asset with the name "Test Asset"
     asset_tags = asset.get_tags() # Gets the list of all tags
+
     asset_data = asset.data(start_time=1000000, stop_time=2000000) # Get the data of the asset for the given interval between start_time and stop_time. This returns downsampled tag data.
-    print(asset_data) # Returns the data present in dataframe format
+    print(asset_data) # Returns the data present in wide dataframe format.
+
+    asset_data = asset.data(start_time=1000000, stop_time=2000000, wide_df=False) # Get the data of the asset for the given interval between start_time and stop_time in long df format. This returns downsampled tag data.
+    print(asset_data) # Returns the data present in long dataframe format.
 
     # For getting raw data we need to use freeflowpaginated query using Graphql Client
     # Below is the example for the same

--- a/quartic_sdk/core/entities/asset.py
+++ b/quartic_sdk/core/entities/asset.py
@@ -69,20 +69,14 @@ class Asset(Base):
             batches_response,
             self.api_helper)
 
-    def data(
-            self,
-            start_time,
-            stop_time,
-            sampling_value=1500,
-            return_type=Constants.RETURN_PANDAS,
-            transformations=[],
-            ):
+    def data(self, start_time, stop_time, sampling_data_points=1500, return_type=Constants.RETURN_PANDAS,
+             transformations=[], wide_df=True):
         """
         Get the data of all tags in the asset between the given start_time and
         stop_time for the given sampling_ratio
         :param start_time: (epoch) Start_time for getting data
         :param stop_time: (epoch) Stop_time for getting data
-        :param sampling_ratio: sampling_ratio of the data
+        :param sampling_data_points: sampling_ratio of the data
         :param return_type: The param decides whether the data after querying will be
             json(when value is "json") or pandas dataframe(when value is "pd"). By default,
             it takes the value as "json"
@@ -103,20 +97,16 @@ class Asset(Base):
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
+        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
         tags = self.get_tags().exclude(
             tag_data_type=Constants.TAG_DATA_TYPES[Constants.SPECTRAL])
         logging.info("Filtering to fetch data only for non-spectral tags")
-        return TagData.get_tag_data(
-            tags=tags,
-            start_time=start_time,
-            stop_time=stop_time,
-            api_helper=self.api_helper,
-            sampling_value=sampling_value,
-            return_type=return_type,
-            transformations=transformations)
+        return TagData.get_tag_data(tags=tags, start_time=start_time, stop_time=stop_time, api_helper=self.api_helper,
+                                    sampling_data_points=sampling_data_points, return_type=return_type,
+                                    transformations=transformations, wide_df=wide_df)
 
     def __getattribute__(self, name):
         """

--- a/quartic_sdk/core/entities/edge_connector.py
+++ b/quartic_sdk/core/entities/edge_connector.py
@@ -55,13 +55,14 @@ class EdgeConnector(Base):
         return HistoricalTagDataIterator(tags, self.id, start_time, stop_time, self.api_helper, batch_size, max_records,
             return_type)
 
-    def data(self, start_time, stop_time, sampling_value=1500, return_type=Constants.RETURN_PANDAS, transformations=[]):
+    def data(self, start_time, stop_time, sampling_data_points=1500, return_type=Constants.RETURN_PANDAS,
+             transformations=[], wide_df=True):
         """
         Get the data of all tags in the edge connector between the given start_time and
         stop_time for the given sampling_ratio
         :param start_time: (epoch) Start_time for getting data
         :param stop_time: (epoch) Stop_time for getting data
-        :param sampling_ratio: sampling_ratio of the data
+        :param sampling_data_points: sampling_ratio of the data
         :param return_type: The param decides whether the data after querying will be
             json(when value is "json") or pandas dataframe(when value is "pd"). By default,
             it takes the value as "json"
@@ -82,18 +83,14 @@ class EdgeConnector(Base):
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
+        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
         tags = self.get_tags()
-        return TagData.get_tag_data(
-            tags=tags,
-            start_time=start_time,
-            stop_time=stop_time,
-            api_helper=self.api_helper,
-            sampling_value=sampling_value,
-            return_type=return_type,
-            transformations=transformations)
+        return TagData.get_tag_data(tags=tags, start_time=start_time, stop_time=stop_time, api_helper=self.api_helper,
+                                    sampling_data_points=sampling_data_points, return_type=return_type,
+                                    transformations=transformations, wide_df=wide_df)
 
     def __getattribute__(self, name):
         """

--- a/quartic_sdk/core/entities/tag.py
+++ b/quartic_sdk/core/entities/tag.py
@@ -47,20 +47,14 @@ class Tag(Base):
         """
         return f"<{Constants.TAG_ENTITY}: {self.name}>"
 
-    def data(
-            self,
-            start_time,
-            stop_time,
-            sampling_value=1500,
-            return_type=Constants.RETURN_PANDAS,
-            wavelengths = [],
-            transformations=[]):
+    def data(self, start_time, stop_time, sampling_data_points=1500, return_type=Constants.RETURN_PANDAS,
+             wavelengths=[], transformations=[], wide_df=True):
         """
         Get the data for the given tag between the start_time and the stop_time
         for the given sampling_ratio
         :param start_time: (epoch) Start_time for getting data
         :param stop_time: (epoch) Stop_time for getting data
-        :param sampling_ratio: sampling_ratio of the data
+        :param sampling_data_points: sampling_ratio of the data
         :param return_type: The param decides whether the data after querying will be
             json(when value is "json") or pandas dataframe(when value is "pd"). By default,
             it takes the value as "json"
@@ -85,6 +79,7 @@ class Tag(Base):
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
+        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
@@ -93,17 +88,11 @@ class Tag(Base):
             raise IncorrectTagParameterException( "Invalid parameters : Wavelengths are only supported with spectral tag type")                    
         if wavelengths:
             Tag.raise_exception_for_wavelegths(wavelengths)
-        return TagData.get_tag_data(
-            tags=EntityList(
-                Constants.TAG_ENTITY,
-                [self]),
-            start_time=start_time,
-            stop_time=stop_time,
-            api_helper=self.api_helper,
-            sampling_value=sampling_value,
-            return_type=return_type,
-            wavelengths=wavelengths,
-            transformations=transformations)
+        return TagData.get_tag_data(tags=EntityList(
+            Constants.TAG_ENTITY,
+            [self]), start_time=start_time, stop_time=stop_time, api_helper=self.api_helper,
+            sampling_data_points=sampling_data_points, return_type=return_type, wavelengths=wavelengths,
+            transformations=transformations, wide_df=wide_df)
 
     def wavelengths(self, start_time=None, stop_time=None):
         """

--- a/quartic_sdk/core/entity_helpers/entity_list.py
+++ b/quartic_sdk/core/entity_helpers/entity_list.py
@@ -148,20 +148,14 @@ class EntityList:
         """
         return self.count() > 0
 
-    def data(
-            self,
-            start_time,
-            stop_time,
-            sampling_value=1500,
-            return_type=Constants.RETURN_PANDAS,
-            transformations=[],
-            ):
+    def data(self, start_time, stop_time, sampling_data_points=1500, return_type=Constants.RETURN_PANDAS,
+             transformations=[], wide_df=True):
         """
         Get the data of all tags in the list between the given start_time and
         stop_time for the given sampling_ratio
         :param start_time: (epoch) Start_time for getting data
         :param stop_time: (epoch) Stop_time for getting data
-        :param sampling_ratio: sampling_ratio of the data
+        :param sampling_data_points: sampling_ratio of the data
         :param return_type: The param decides whether the data after querying will be
             json(when value is "json") or pandas dataframe(when value is "pd"). By default,
             it takes the value as "json"
@@ -182,15 +176,11 @@ class EntityList:
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
+        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
         assert self._class_type == Constants.TAG_ENTITY
-        return TagData.get_tag_data(
-            tags=self,
-            start_time=start_time,
-            stop_time=stop_time,
-            api_helper=self.first().api_helper,
-            sampling_value=sampling_value,
-            return_type=return_type,
-            transformations=transformations)
+        return TagData.get_tag_data(tags=self, start_time=start_time, stop_time=stop_time,
+                                    api_helper=self.first().api_helper, sampling_data_points=sampling_data_points,
+                                    return_type=return_type, transformations=transformations, wide_df=wide_df)

--- a/quartic_sdk/utilities/tag_data.py
+++ b/quartic_sdk/utilities/tag_data.py
@@ -100,21 +100,13 @@ class TagData:
                     "Invalid transformations : transformation_type is invalid")
 
     @classmethod
-    def get_tag_data(
-            cls,
-            tags,
-            start_time,
-            stop_time,
-            api_helper,
-            sampling_value=1500,
-            return_type=Constants.RETURN_PANDAS,
-            wavelengths = [],
-            transformations=[]):
+    def get_tag_data(cls, tags, start_time, stop_time, api_helper, sampling_data_points=1500,
+                     return_type=Constants.RETURN_PANDAS, wavelengths=[], transformations=[], wide_df=True):
         """
         The method gets the tag data based upon the parameters that are passed here
         :param start_time: (epoch) Start_time for getting data
         :param stop_time: (epoch) Stop_time for getting data
-        :param sampling_ratio: sampling_ratio of the data
+        :param sampling_data_points: sampling_ratio of the data
         :param return_type: The param decides whether the data after querying will be
             json(when value is "json") or pandas dataframe(when value is "pd"). By default,
             it takes the value as "json"
@@ -139,6 +131,7 @@ class TagData:
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
+        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
@@ -150,8 +143,9 @@ class TagData:
             "tags": [tag.id for tag in tags.all()],
             "start_time": start_time,
             "stop_time": stop_time,
-            "sampling_value": sampling_value,
-            "wavelengths" : wavelengths,
+            "sampling_data_points": sampling_data_points,
+            "wavelengths": wavelengths,
+            "wide_df": wide_df,
             "transformations": transformations
         }
         tag_data_return = api_helper.call_api(


### PR DESCRIPTION
Test 

 
```
client = APIClient("https://qa.quartic.ai", username="**********", password="************")
user_assets = client.assets()
asset = user_assets.get("name", "OSIPI-Asset-1")  # Get a specific asset with the name "Test Asset"
asset_data = asset.data(start_time=1706693453221, stop_time=1706693463221, wide_df=False)
asset_data_wide = asset.data(start_time=1706693453221, stop_time=1706693463221, wide_df=True)
```

`print(asset_data)`

```
               tag_id       value
1706693454000   21173  815.397200
1706693455000   21173  813.783400
1706693456000   21173  811.178955
1706693457000   21173  810.134000
1706693458000   21173  807.375732
...               ...         ...
1706693459000   21194    5.000000
1706693460000   21194    8.000000
1706693461000   21194    0.000000
1706693462000   21194    4.000000
1706693463000   21194    8.000000
[170 rows x 2 columns]
```

`print(asset_data_wide)`

```
                    21173       21174       21175  ...  23862  23863  23870
1706693454000  810.822632  2856.60840  2622.69482  ...   None   None   None
1706693455000  810.457947  2859.00854  2614.93726  ...   None   None   None
1706693456000  809.692900  2862.23877  2613.89014  ...   None   None   None
1706693457000  809.175537  2861.63647  2612.63600  ...   None   None   None
1706693458000  810.329800  2864.42651  2613.15967  ...   None   None   None
1706693459000  811.813900  2871.01758  2608.46900  ...   None   None   None
1706693460000  811.585000  2871.03564  2617.03200  ...   None   None   None
1706693461000  818.343600  2870.81348  2616.09326  ...   None   None   None
1706693462000  813.471900  2869.76440  2617.37915  ...   None   None   None
1706693463000  808.581360  2870.69043  2617.04736  ...   None   None   None
[10 rows x 36 columns]
```