### PR TITLE
QPD-5982: Fetch wide df from TagData and removed wide df flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ asset_tags = asset.get_tags() # Gets the list of all tags
 
 first_tag=asset_tags.first() # Returns the first in the list of tags
 tag_data = first_tag.data(start_time=1000000,stop_time=2000000) # Returns the downsampled data present in the first tag for the time range of 1000000 to 2000000 in wide data format.
-tag_data_long = first_tag.data(start_time=1000000, stop_time=200000, wide_df=False) # Returns the same data, in long format. 
 ```
 ```python
 # For getting raw data we need to use freeflowpaginated query using Graphql Client

--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -419,9 +419,6 @@ The method parameters are as follows:
 -  **transformations (optional)**: The user is supposed to pass the list
    of interpolations and aggregations here. Further details on
    transformations is provided towards the end of this documentation.
--  **wide\_df (optional)**: When passed as ``true``, the data is returned
-   in a wide format, and when passed as ``false``, it is returned in a
-   long format. By default, the setting is ``true``.
 
 Tag
 ------
@@ -539,9 +536,6 @@ parameter you can control the downsampled points. The method parameters are as f
 -  **transformations (optional)**: The user is supposed to pass the list
    of interpolations and aggregations here. Further details on
    transformations is provided towards the end of this documentation.
--  **wide\_df (optional)**: When passed as ``true``, the data is returned
-   in a wide format, and when passed as ``false``, it is returned in a
-   long format. By default, the setting is ``true``.
 
 
 .wavelengths
@@ -668,9 +662,6 @@ The method parameters are as follows:
 -  **transformations (optional)**: The user must pass the list
    of interpolations and aggregations here. Further details on
    transformations is provided towards the end of this documentation.
--  **wide\_df (optional)**: When passed as ``true``, the data is returned
-   in a wide format, and when passed as ``false``, it is returned in a
-   long format. By default, the setting is ``true``.
 
 .historical_data
 ~~~~~~~~~~~~~~~~
@@ -901,9 +892,6 @@ data for given tags, and has the following parameters:
 -  **transformations (optional)**: The user must pass the list
    of interpolations and aggregations here. Further details on
    transformations is provided towards the end of this documentation.
--  **wide\_df (optional)**: When passed as ``true``, the data is returned
-    in a wide format, and when passed as ``false``, it is returned in a
-    long format. By default, the setting is ``true``.
 
 TagData
 ------------------

--- a/docs/source/home.rst
+++ b/docs/source/home.rst
@@ -112,12 +112,8 @@ Getting the assets, tags, batches from the server
 
     asset = user_assets.get("name","Test Asset") # Get a specific asset with the name "Test Asset"
     asset_tags = asset.get_tags() # Gets the list of all tags
-
     asset_data = asset.data(start_time=1000000, stop_time=2000000) # Get the data of the asset for the given interval between start_time and stop_time. This returns downsampled tag data.
     print(asset_data) # Returns the data present in wide dataframe format.
-
-    asset_data = asset.data(start_time=1000000, stop_time=2000000, wide_df=False) # Get the data of the asset for the given interval between start_time and stop_time in long df format. This returns downsampled tag data.
-    print(asset_data) # Returns the data present in long dataframe format.
 
     # For getting raw data we need to use freeflowpaginated query using Graphql Client
     # Below is the example for the same

--- a/quartic_sdk/core/entities/asset.py
+++ b/quartic_sdk/core/entities/asset.py
@@ -70,7 +70,7 @@ class Asset(Base):
             self.api_helper)
 
     def data(self, start_time, stop_time, sampling_data_points=1500, return_type=Constants.RETURN_PANDAS,
-             transformations=[], wide_df=True):
+             transformations=[]):
         """
         Get the data of all tags in the asset between the given start_time and
         stop_time for the given sampling_ratio
@@ -97,7 +97,6 @@ class Asset(Base):
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
-        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
@@ -106,7 +105,7 @@ class Asset(Base):
         logging.info("Filtering to fetch data only for non-spectral tags")
         return TagData.get_tag_data(tags=tags, start_time=start_time, stop_time=stop_time, api_helper=self.api_helper,
                                     sampling_data_points=sampling_data_points, return_type=return_type,
-                                    transformations=transformations, wide_df=wide_df)
+                                    transformations=transformations)
 
     def __getattribute__(self, name):
         """

--- a/quartic_sdk/core/entities/edge_connector.py
+++ b/quartic_sdk/core/entities/edge_connector.py
@@ -56,7 +56,7 @@ class EdgeConnector(Base):
             return_type)
 
     def data(self, start_time, stop_time, sampling_data_points=1500, return_type=Constants.RETURN_PANDAS,
-             transformations=[], wide_df=True):
+             transformations=[]):
         """
         Get the data of all tags in the edge connector between the given start_time and
         stop_time for the given sampling_ratio
@@ -83,14 +83,13 @@ class EdgeConnector(Base):
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
-        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
         tags = self.get_tags()
         return TagData.get_tag_data(tags=tags, start_time=start_time, stop_time=stop_time, api_helper=self.api_helper,
                                     sampling_data_points=sampling_data_points, return_type=return_type,
-                                    transformations=transformations, wide_df=wide_df)
+                                    transformations=transformations)
 
     def __getattribute__(self, name):
         """

--- a/quartic_sdk/core/entities/tag.py
+++ b/quartic_sdk/core/entities/tag.py
@@ -48,7 +48,7 @@ class Tag(Base):
         return f"<{Constants.TAG_ENTITY}: {self.name}>"
 
     def data(self, start_time, stop_time, sampling_data_points=1500, return_type=Constants.RETURN_PANDAS,
-             wavelengths=[], transformations=[], wide_df=True):
+             wavelengths=[], transformations=[]):
         """
         Get the data for the given tag between the start_time and the stop_time
         for the given sampling_ratio
@@ -79,7 +79,6 @@ class Tag(Base):
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
-        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
@@ -92,7 +91,7 @@ class Tag(Base):
             Constants.TAG_ENTITY,
             [self]), start_time=start_time, stop_time=stop_time, api_helper=self.api_helper,
             sampling_data_points=sampling_data_points, return_type=return_type, wavelengths=wavelengths,
-            transformations=transformations, wide_df=wide_df)
+            transformations=transformations)
 
     def wavelengths(self, start_time=None, stop_time=None):
         """

--- a/quartic_sdk/core/entity_helpers/entity_list.py
+++ b/quartic_sdk/core/entity_helpers/entity_list.py
@@ -149,7 +149,7 @@ class EntityList:
         return self.count() > 0
 
     def data(self, start_time, stop_time, sampling_data_points=1500, return_type=Constants.RETURN_PANDAS,
-             transformations=[], wide_df=True):
+             transformations=[]):
         """
         Get the data of all tags in the list between the given start_time and
         stop_time for the given sampling_ratio
@@ -176,11 +176,10 @@ class EntityList:
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
-        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
         assert self._class_type == Constants.TAG_ENTITY
         return TagData.get_tag_data(tags=self, start_time=start_time, stop_time=stop_time,
                                     api_helper=self.first().api_helper, sampling_data_points=sampling_data_points,
-                                    return_type=return_type, transformations=transformations, wide_df=wide_df)
+                                    return_type=return_type, transformations=transformations)

--- a/quartic_sdk/utilities/tag_data.py
+++ b/quartic_sdk/utilities/tag_data.py
@@ -101,7 +101,7 @@ class TagData:
 
     @classmethod
     def get_tag_data(cls, tags, start_time, stop_time, api_helper, sampling_data_points=1500,
-                     return_type=Constants.RETURN_PANDAS, wavelengths=[], transformations=[], wide_df=True):
+                     return_type=Constants.RETURN_PANDAS, wavelengths=[], transformations=[]):
         """
         The method gets the tag data based upon the parameters that are passed here
         :param start_time: (epoch) Start_time for getting data
@@ -131,7 +131,6 @@ class TagData:
                 "aggregation_dict": {"3": "max"},
                 "aggregation_timestamp": "last",
             }]
-        :param wide_df: bool to get data in wide_dataframe format
         :return: (DataIterator) DataIterator object which can be iterated to get the data
             between the given duration
         """
@@ -145,7 +144,6 @@ class TagData:
             "stop_time": stop_time,
             "sampling_data_points": sampling_data_points,
             "wavelengths": wavelengths,
-            "wide_df": wide_df,
             "transformations": transformations
         }
         tag_data_return = api_helper.call_api(


### PR DESCRIPTION
   Test:
   
 ```
   from quartic_sdk import APIClient
    client = APIClient("https://qa.quartic.ai", username="*******", password=-"---")
    user_assets = client.assets()
    asset = user_assets.get("name", "OSIPI-Asset-1")  # Get a specific asset with the name "Test Asset"
    asset_data = asset.data(start_time=1706693453221, stop_time=1706693463221)
    print(asset_data)
```
    
    
    
    
```
    asset_data
Out[2]: 
                
   21173       21174       21175  ...  21192  21193  21194
1706693454000  810.822632  2859.11900  2622.69482  ...  100.0   84.0    1.0
1706693455000  813.783400  2859.00854  2618.87622  ...  143.0  127.0    6.0
1706693456000  811.178955  2861.26831  2613.89014  ...   57.0   22.0    4.0
1706693457000  810.134000  2861.63647  2614.70728  ...   75.0   51.0    2.0
1706693458000  807.375732  2864.42651  2613.15967  ...   93.0  115.0    1.0
1706693459000  812.712200  2871.01758  2612.82983  ...   64.0  174.0    5.0
1706693460000  813.983900  2871.03564  2617.03200  ...  180.0    3.0    8.0
1706693461000  814.076050  2874.12939  2616.09326  ...  198.0  173.0    0.0
1706693462000  810.191345  2872.02612  2617.64453  ...    4.0   98.0    4.0
1706693463000  808.581360  2870.69043  2617.04736  ...   49.0   46.0    8.0

```


```
asset_data.columns
Out[3]: 
Index(['21173', '21174', '21175', '21176', '21177', '21178', '21179', '21180',
       '21181', '21182', '21183', '21184', '21185', '21191', '21192', '21193',
```


cc @tushar-quartic @scriperdjq 